### PR TITLE
chore(codecov) : Add multiple statuses to codecov.

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,25 +1,27 @@
 codecov:
   branch: master
+  bot: thomaslevans-wf
 
 coverage:
-  precision: 2
-  round: down
-  range: "70...100"
-
   status:
     project:
-      default:
-        target: auto
+      unit:
+        paths:
+          - "test/unit/"
+      integration:
+        paths:
+          - "test/integration/"
 
     patch:
-      default:
-        target: auto
-
-    changes:
-      default:
-        branches: null
+      unit:
+        paths:
+          - "test/unit/"
+      integration:
+        paths:
+          - "test/integration/"
 
 comment:
-  layout: "header, diff, changes, sunburst, uncovered, tree"
+  layout: "header, diff"
   branches: null
   behavior: default
+  require_changes: false


### PR DESCRIPTION
Add multiple statuses to codecov reporting for better visibility of testing effort. The status will partition test coverage based on the testing pyramid. This translates to having coverage reports for both unit and integration tests on this project.
